### PR TITLE
Run babel on output bundles

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
-{
-  "presets": ["@babel/preset-env"]
+{ 
+  "presets": [["@babel/env", { "modules": "auto"}]],
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",
+    "@babel/plugin-transform-runtime": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
     "@rollup/plugin-alias": "^3.1.8",
     "@rollup/plugin-babel": "^5.3.0",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -2,7 +2,7 @@ import serve from 'rollup-plugin-serve';
 import livereload from 'rollup-plugin-livereload';
 import alias from '@rollup/plugin-alias';
 import vue from 'rollup-plugin-vue2';
-import babel from '@rollup/plugin-babel';
+import { getBabelOutputPlugin } from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import postcss from 'rollup-plugin-postcss';
 import commonjs from '@rollup/plugin-commonjs';
@@ -11,11 +11,12 @@ import replace from '@rollup/plugin-replace';
 module.exports = {
   input: 'src/main.js',
   output: {
+    format: 'es',
     dir: 'example',
     entryFileNames: 'App.js',
-    format: 'iife',
     sourcemap: 'inline',
     name: 'App',
+    plugins: [getBabelOutputPlugin()],
   },
   plugins: [
     commonjs(),
@@ -23,10 +24,6 @@ module.exports = {
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),
       'process.env.VUE_ENV': JSON.stringify('browser')
-    }),
-    babel({ 
-      babelHelpers: 'bundled',
-      exclude: 'node_modules/**',
     }),
     postcss({
       extensions: [ '.css' ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
 import alias from '@rollup/plugin-alias';
 import vue from 'rollup-plugin-vue2';
-import babel from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import postcss from 'rollup-plugin-postcss';
 import commonjs from '@rollup/plugin-commonjs';
 import pkg from './package.json';
+import { getBabelOutputPlugin } from '@rollup/plugin-babel';
 
 module.exports = {
   input: 'src/package.js',
@@ -24,7 +24,7 @@ module.exports = {
           'vue': 'Vue',
           '@vue/composition-api': 'VueCompositionAPI',
           'vue2-datepicker': 'DatePicker',
-        }
+        },
     },
     {
         file: pkg.module,
@@ -32,15 +32,14 @@ module.exports = {
         exports: "named",
         name: 'refine-vue2',
         sourcemap: true,
+        plugins: [getBabelOutputPlugin({ 
+          presets: [['@babel/env', { modules: 'umd' }]] 
+        })]
     },
   ],
   plugins: [
     commonjs(),
     vue(),
-    babel({ 
-      babelHelpers: 'bundled',
-      exclude: 'node_modules/**',
-    }),
     postcss({
       extensions: [ '.css' ],
       extract: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,7 +821,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.5"
 
-"@babel/plugin-transform-runtime@^7.11.0":
+"@babel/plugin-transform-runtime@^7.11.0", "@babel/plugin-transform-runtime@^7.16.5":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.5.tgz#0cc3f01d69f299d5a42cd9ec43b92ea7a777b8db"
   integrity sha512-gxpfS8XQWDbQ8oP5NcmpXxtEgCJkbO+W9VhZlOhr0xPyVaRjAQPOv7ZDj9fg0d5s9+NiVvMCE6gbkEkcsxwGRw==


### PR DESCRIPTION
Run babel on the output bundles from rollup which allows us to target a lower level of browser like IE11. Running it on input files does not allow us to support older files https://www.npmjs.com/package/@rollup/plugin-babel#running-babel-on-the-generated-code
