### PR TITLE
Use shared `BlueprintStore` in React implementation

### DIFF
--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
+import type { Condition, Blueprint } from "@hammerstone/refine-react";
 import { QueryBuilder } from "@hammerstone/refine-react";
-import type { Condition, Blueprint } from "refine-core/types"; // move to @hammerstone/refine-react
 import {
   booleanCondition,
   dateCondition,

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { QueryBuilder, groupBlueprintItems } from "@hammerstone/refine-react";
+import { QueryBuilder } from "@hammerstone/refine-react";
 import type { Condition, Blueprint } from "refine-core/types"; // move to @hammerstone/refine-react
 import {
   booleanCondition,
@@ -59,16 +59,14 @@ const conditions: Condition[] = [
 ];
 
 const App = () => {
-  const [debugBlueprint, setDebugBlueprint] = useState(() =>
-    groupBlueprintItems(blueprint)
-  );
+  const [debugBlueprint, setDebugBlueprint] = useState(blueprint);
 
   return (
     <div>
       <QueryBuilder
         blueprint={blueprint}
         conditions={conditions}
-        onChange={(groupedBlueprint) => setDebugBlueprint(groupedBlueprint)}
+        onChange={(blueprint) => setDebugBlueprint(blueprint)}
       />
       <pre className="text-xs">{JSON.stringify(debugBlueprint, null, 2)}</pre>
     </div>

--- a/examples/vue2/App.vue
+++ b/examples/vue2/App.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
     <div class="w-max">
-      <query-builder 
+      <query-builder
         :errors="errors"
-        :conditions="conditions" 
-        v-model="groupedBlueprint" 
-        class="p-4 w-100" 
+        :conditions="conditions"
+        v-model="groupedBlueprint"
+        class="p-4 w-100"
       />
     </div>
     <div>{{ groupedBlueprint }}</div>
@@ -51,512 +51,650 @@
 
 <script>
 import { QueryBuilder } from "../../packages/refine-vue/dist/vue2/refine-vue.esm";
-import './main.css';
+import "./main.css";
 import "../../packages/refine-vue/dist/vue2/refine-vue.esm.css";
 
-const groupedBlueprint = [];
+const groupedBlueprint = [
+  {
+    condition_id: "option",
+    depth: 1,
+    type: "criterion",
+    input: { clause: "in" },
+    uid: 0,
+  },
+  { depth: 1, type: "conjunction", word: "and" },
+  {
+    condition_id: "option",
+    depth: 1,
+    type: "criterion",
+    input: { clause: "in" },
+    uid: 1,
+  },
+];
 
-const conditions = [{
-  id: "option",
-  component: "refine-option-condition",
-  display: "Option",
-  meta: {
-    clauses: [
-      {
-        id: "in",
-        component: "refine-option-input",
-        display: "Is One Of",
-        meta: { multiple: true },
-      },
-      {
-        id: "eq",
-        component: "refine-option-input",
-        display: "Is",
-        meta: {},
-      },
-      {
-        id: "dne",
-        component: "refine-option-input",
-        display: "Is Not",
-        meta: {},
-      },
-      {
-        id: "nin",
-        component: "refine-option-input",
-        display: "Is Not One Of",
-        meta: { multiple: true },
-      },
-      {
-        id: "st",
-        display: "Is Set",
-        meta: {},
-      },
-      {
-        id: "nst",
-        display: "Is Not Set",
-        meta: {},
-      },
-    ],
-    options: [
-      {
-        id: "foo",
-        display: "Foo",
-      },
-      {
-        id: "bar",
-        display: "Bar",
-      },
-      {
-        id: "foo2",  
-        display: "Foo2",
-      },
-      {
-        id: "bar2",
-        display: "Bar2",
-      },
-    ],
-  },
-  refinements: [],
-},
-{
-  id: "text",
-  display: "Text",
-  meta: {
-    clauses: [
-      {
-        id: "eq",
-        display: "Equals",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "dne",
-        display: "Does Not Equal",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "sw",
-        display: "Starts With",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "ew",
-        display: "Ends With",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "dsw",
-        display: "Does Not Start With",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "dew",
-        display: "Does Not End With",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "cont",
-        display: "Contains",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "dcont",
-        display: "Does Not Contain",
-        component: "refine-text-input",
-        meta: {},
-      },
-      {
-        id: "st",
-        display: "Is Set",
-        meta: {},
-      },
-      {
-        id: "nst",
-        display: "Is Not Set",
-        meta: {},
-      },
-    ],
-  },
-  refinements: [],
-},
-{
-  id: "bool",
-  component: "boolean-condition",
-  display: "Bool",
-  meta: {
-    clauses: [
-      {
-        id: "true",
-        display: "Is True",
-        meta: {},
-      },
-      {
-        id: "false",
-        display: "Is False",
-        meta: {},
-      },
-    ],
-  },
-  refinements: [],
-},
-{
-  id: "date",
-  component: "date-condition",
-  display: "Date",
-  meta: {
-    format: "YYYY/MM/DD",
-    clauses: [
-      {
-        id: "eq",
-        display: "Is Equal To",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "dne",
-        display: "Is Not Equal To",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "lte",
-        display: "Is On or Before",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "gte",
-        display: "Is On or After",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "btwn",
-        display: "Is Between",
-        component: "refine-double-date-input",
-        meta: {},
-      },
-      {
-        id: "gt",
-        display: "Is More Than",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "exct",
-        display: "Is Exactly",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "lt",
-        display: "Is Less Than",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "st",
-        display: "Is Set",
-        meta: {},
-      },
-      {
-        id: "nst",
-        display: "Is Not Set",
-        meta: {},
-      },
-    ],
-  },
-  refinements: [],
-},
-{
-  id: "date_with_time",
-  component: "date-condition",
-  display: "Date With Time",
-  meta: {
-    clauses: [
-      {
-        id: "eq",
-        display: "Is Equal To",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "dne",
-        display: "Is Not Equal To",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "lte",
-        display: "Is On or Before",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "gte",
-        display: "Is On or After",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "btwn",
-        display: "Is Between",
-        component: "refine-double-date-input",
-        meta: {},
-      },
-      {
-        id: "gt",
-        display: "Is More Than",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "exct",
-        display: "Is Exactly",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "lt",
-        display: "Is Less Than",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "st",
-        display: "Is Set",
-        meta: {},
-      },
-      {
-        id: "nst",
-        display: "Is Not Set",
-        meta: {},
-      },
-    ],
-  },
-  refinements: [],
-},
-{
-  id: "timestamp",
-  component: "date-condition",
-  display: "Timestamp",
-  meta: {
-    clauses: [
-      {
-        id: "eq",
-        display: "Is Equal To",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "dne",
-        display: "Is Not Equal To",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "lte",
-        display: "Is On or Before",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "gte",
-        display: "Is On or After",
-        component: "refine-date-input",
-        meta: {},
-      },
-      {
-        id: "btwn",
-        display: "Is Between",
-        component: "refine-double-date-input",
-        meta: {},
-      },
-      {
-        id: "gt",
-        display: "Is More Than",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "exct",
-        display: "Is Exactly",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "lt",
-        display: "Is Less Than",
-        component: "refine-relative-date-input",
-        meta: {},
-      },
-      {
-        id: "st",
-        display: "Is Set",
-        meta: {},
-      },
-      {
-        id: "nst",
-        display: "Is Not Set",
-        meta: {},
-      },
-    ],
-  },
-  refinements: [],
-},
-{
-  id: "numeric",
-  component: "numeric-condition",
-  display: "Numeric",
-  meta: {
-    clauses: [        
-      {
-        id: "eq",
-        display: "Is Equal To",
-        component: "refine-number-input",
-        meta: {},
-      },
-      {
-        id: "dne",
-        display: "Is Not Equal To",
-        component: "refine-number-input",
-        meta: {},
-      },
-      {
-        id: "gt",
-        display: "Is Greater Than",
-        component: "refine-number-input",
-        meta: {},
-      },
-      {
-        id: "gte",
-        display: "Is Greater Than Or Equal To",
-        component: "refine-number-input",
-        meta: {},
-      },
-      {
-        id: "lt",
-        display: "Is Less Than",
-        component: "refine-number-input",
-        meta: {},
-      },
-      {
-        id: "lte",
-        display: "Is Less Than Or Equal To",
-        component: "refine-number-input",
-        meta: {},
-      },
-      {
-        id: "btwn",
-        display: "Is Between",
-        component: "refine-double-number-input",
-        meta: {},
-      },
-      {
-        id: "nbtwn",
-        display: "Is Not Between",
-        component: "refine-double-number-input",
-        meta: {},
-      },
-      {
-        id: "st",
-        display: "Is Set",
-        meta: {},
-      },
-      {
-        id: "nst",
-        display: "Is Not Set",
-        meta: {},
-      },
-    ],
-  },
-  refinements: [],
-},    
-{
-  "id": "events.name",
-  "display": "Events.Name",
-  "meta": {
-    "clauses": [
-      { "id": "eq", "display": "Equals", "meta": {}, "component": "refine-text-input" },
-      { "id": "dne", "display": "Does Not Equal", "meta": {}, "component": "refine-text-input" },
-      { "id": "sw", "display": "Starts With", "meta": {}, "component": "refine-text-input" },
-      { "id": "ew", "display": "Ends With", "meta": {}, "component": "refine-text-input" },
-      { "id": "dsw", "display": "Does Not Start With", "meta": {}, "component": "refine-text-input" },
-      { "id": "dew", "display": "Does Not End With", "meta": {}, "component": "refine-text-input" },
-      { "id": "cont", "display": "Contains", "meta": {}, "component": "refine-text-input" },
-      { "id": "dcont", "display": "Does Not Contain", "meta": {}, "component": "refine-text-input" },
-      { "id": "st", "display": "Is Set", "meta": {}, "component": "refine-text-input" },
-      { "id": "nst", "display": "Is Not Set", "meta": {}, "component": "refine-text-input" }
-    ]
-  },
-  "refinements": [
-    {
-      "id": "count_refinement",
-      "display": "Count Refinement",
-      "meta": {
-        "clauses": [
-          { "id": "eq", "display": "Is Equal To", "meta": {}, "component": "refine-number-input" },
-          { "id": "dne", "display": "Is Not Equal To", "meta": {}, "component": "refine-number-input" },
-          { "id": "gt", "display": "Is Greater Than", "meta": {}, "component": "refine-number-input" },
-          {
-            "id": "gte",
-            "display": "Is Greater Than Or Equal To",
-            "meta": {}, 
-            "component": "refine-number-input"
-          },
-          { "id": "lt", "display": "Is Less Than", "meta": {} },
-          {
-            "id": "lte",
-            "display": "Is Less Than Or Equal To",
-            "meta": {}, 
-            "component": "refine-number-input"
-          },
-          { "id": "btwn", "display": "Is Between", "meta": {}, "component": "refine-number-input" },
-          { "id": "nbtwn", "display": "Is Not Between", "meta": {}, "component": "refine-number-input" },
-          { "id": "st", "display": "Is Set", "meta": {}, "component": "refine-number-input" },
-          { "id": "nst", "display": "Is Not Set", "meta": {}, "component": "refine-number-input" }
-        ]
-      },
-      "refinements": []
-    }, {
-      "id": "kaboom_refinement",
-      "display": "Kaboom Refinement",
-      "meta": {
-        "clauses": [
-          { "id": "eq", "display": "Is Equal To", "meta": {}, "component": "refine-number-input" },
-          { "id": "dne", "display": "Is Not Equal To", "meta": {}, "component": "refine-number-input" },
-          { "id": "gt", "display": "Is Greater Than", "meta": {}, "component": "refine-number-input" },
-          {
-            "id": "gte",
-            "display": "Is Greater Than Or Equal To",
-            "meta": {}, 
-            "component": "refine-number-input"
-          },
-          { "id": "lt", "display": "Is Less Than", "meta": {} },
-          {
-            "id": "lte",
-            "display": "Is Less Than Or Equal To",
-            "meta": {}, 
-            "component": "refine-number-input"
-          },
-          { "id": "btwn", "display": "Is Between", "meta": {}, "component": "refine-number-input" },
-          { "id": "nbtwn", "display": "Is Not Between", "meta": {}, "component": "refine-number-input" },
-          { "id": "st", "display": "Is Set", "meta": {}, "component": "refine-number-input" },
-          { "id": "nst", "display": "Is Not Set", "meta": {}, "component": "refine-number-input" }
-        ]
-      },
-      refinements: [],
+const conditions = [
+  {
+    id: "option",
+    component: "refine-option-condition",
+    display: "Option",
+    meta: {
+      clauses: [
+        {
+          id: "in",
+          component: "refine-option-input",
+          display: "Is One Of",
+          meta: { multiple: true },
+        },
+        {
+          id: "eq",
+          component: "refine-option-input",
+          display: "Is",
+          meta: {},
+        },
+        {
+          id: "dne",
+          component: "refine-option-input",
+          display: "Is Not",
+          meta: {},
+        },
+        {
+          id: "nin",
+          component: "refine-option-input",
+          display: "Is Not One Of",
+          meta: { multiple: true },
+        },
+        {
+          id: "st",
+          display: "Is Set",
+          meta: {},
+        },
+        {
+          id: "nst",
+          display: "Is Not Set",
+          meta: {},
+        },
+      ],
+      options: [
+        {
+          id: "foo",
+          display: "Foo",
+        },
+        {
+          id: "bar",
+          display: "Bar",
+        },
+        {
+          id: "foo2",
+          display: "Foo2",
+        },
+        {
+          id: "bar2",
+          display: "Bar2",
+        },
+      ],
     },
-  ]
-}
-  ];
-  
+    refinements: [],
+  },
+  {
+    id: "text",
+    display: "Text",
+    meta: {
+      clauses: [
+        {
+          id: "eq",
+          display: "Equals",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "dne",
+          display: "Does Not Equal",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "sw",
+          display: "Starts With",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "ew",
+          display: "Ends With",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "dsw",
+          display: "Does Not Start With",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "dew",
+          display: "Does Not End With",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "cont",
+          display: "Contains",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "dcont",
+          display: "Does Not Contain",
+          component: "refine-text-input",
+          meta: {},
+        },
+        {
+          id: "st",
+          display: "Is Set",
+          meta: {},
+        },
+        {
+          id: "nst",
+          display: "Is Not Set",
+          meta: {},
+        },
+      ],
+    },
+    refinements: [],
+  },
+  {
+    id: "bool",
+    component: "boolean-condition",
+    display: "Bool",
+    meta: {
+      clauses: [
+        {
+          id: "true",
+          display: "Is True",
+          meta: {},
+        },
+        {
+          id: "false",
+          display: "Is False",
+          meta: {},
+        },
+      ],
+    },
+    refinements: [],
+  },
+  {
+    id: "date",
+    component: "date-condition",
+    display: "Date",
+    meta: {
+      format: "YYYY/MM/DD",
+      clauses: [
+        {
+          id: "eq",
+          display: "Is Equal To",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "dne",
+          display: "Is Not Equal To",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "lte",
+          display: "Is On or Before",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "gte",
+          display: "Is On or After",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "btwn",
+          display: "Is Between",
+          component: "refine-double-date-input",
+          meta: {},
+        },
+        {
+          id: "gt",
+          display: "Is More Than",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "exct",
+          display: "Is Exactly",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "lt",
+          display: "Is Less Than",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "st",
+          display: "Is Set",
+          meta: {},
+        },
+        {
+          id: "nst",
+          display: "Is Not Set",
+          meta: {},
+        },
+      ],
+    },
+    refinements: [],
+  },
+  {
+    id: "date_with_time",
+    component: "date-condition",
+    display: "Date With Time",
+    meta: {
+      clauses: [
+        {
+          id: "eq",
+          display: "Is Equal To",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "dne",
+          display: "Is Not Equal To",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "lte",
+          display: "Is On or Before",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "gte",
+          display: "Is On or After",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "btwn",
+          display: "Is Between",
+          component: "refine-double-date-input",
+          meta: {},
+        },
+        {
+          id: "gt",
+          display: "Is More Than",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "exct",
+          display: "Is Exactly",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "lt",
+          display: "Is Less Than",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "st",
+          display: "Is Set",
+          meta: {},
+        },
+        {
+          id: "nst",
+          display: "Is Not Set",
+          meta: {},
+        },
+      ],
+    },
+    refinements: [],
+  },
+  {
+    id: "timestamp",
+    component: "date-condition",
+    display: "Timestamp",
+    meta: {
+      clauses: [
+        {
+          id: "eq",
+          display: "Is Equal To",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "dne",
+          display: "Is Not Equal To",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "lte",
+          display: "Is On or Before",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "gte",
+          display: "Is On or After",
+          component: "refine-date-input",
+          meta: {},
+        },
+        {
+          id: "btwn",
+          display: "Is Between",
+          component: "refine-double-date-input",
+          meta: {},
+        },
+        {
+          id: "gt",
+          display: "Is More Than",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "exct",
+          display: "Is Exactly",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "lt",
+          display: "Is Less Than",
+          component: "refine-relative-date-input",
+          meta: {},
+        },
+        {
+          id: "st",
+          display: "Is Set",
+          meta: {},
+        },
+        {
+          id: "nst",
+          display: "Is Not Set",
+          meta: {},
+        },
+      ],
+    },
+    refinements: [],
+  },
+  {
+    id: "numeric",
+    component: "numeric-condition",
+    display: "Numeric",
+    meta: {
+      clauses: [
+        {
+          id: "eq",
+          display: "Is Equal To",
+          component: "refine-number-input",
+          meta: {},
+        },
+        {
+          id: "dne",
+          display: "Is Not Equal To",
+          component: "refine-number-input",
+          meta: {},
+        },
+        {
+          id: "gt",
+          display: "Is Greater Than",
+          component: "refine-number-input",
+          meta: {},
+        },
+        {
+          id: "gte",
+          display: "Is Greater Than Or Equal To",
+          component: "refine-number-input",
+          meta: {},
+        },
+        {
+          id: "lt",
+          display: "Is Less Than",
+          component: "refine-number-input",
+          meta: {},
+        },
+        {
+          id: "lte",
+          display: "Is Less Than Or Equal To",
+          component: "refine-number-input",
+          meta: {},
+        },
+        {
+          id: "btwn",
+          display: "Is Between",
+          component: "refine-double-number-input",
+          meta: {},
+        },
+        {
+          id: "nbtwn",
+          display: "Is Not Between",
+          component: "refine-double-number-input",
+          meta: {},
+        },
+        {
+          id: "st",
+          display: "Is Set",
+          meta: {},
+        },
+        {
+          id: "nst",
+          display: "Is Not Set",
+          meta: {},
+        },
+      ],
+    },
+    refinements: [],
+  },
+  {
+    id: "events.name",
+    display: "Events.Name",
+    meta: {
+      clauses: [
+        {
+          id: "eq",
+          display: "Equals",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "dne",
+          display: "Does Not Equal",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "sw",
+          display: "Starts With",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "ew",
+          display: "Ends With",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "dsw",
+          display: "Does Not Start With",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "dew",
+          display: "Does Not End With",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "cont",
+          display: "Contains",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "dcont",
+          display: "Does Not Contain",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "st",
+          display: "Is Set",
+          meta: {},
+          component: "refine-text-input",
+        },
+        {
+          id: "nst",
+          display: "Is Not Set",
+          meta: {},
+          component: "refine-text-input",
+        },
+      ],
+    },
+    refinements: [
+      {
+        id: "count_refinement",
+        display: "Count Refinement",
+        meta: {
+          clauses: [
+            {
+              id: "eq",
+              display: "Is Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "dne",
+              display: "Is Not Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "gt",
+              display: "Is Greater Than",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "gte",
+              display: "Is Greater Than Or Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            { id: "lt", display: "Is Less Than", meta: {} },
+            {
+              id: "lte",
+              display: "Is Less Than Or Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "btwn",
+              display: "Is Between",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "nbtwn",
+              display: "Is Not Between",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "st",
+              display: "Is Set",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "nst",
+              display: "Is Not Set",
+              meta: {},
+              component: "refine-number-input",
+            },
+          ],
+        },
+        refinements: [],
+      },
+      {
+        id: "kaboom_refinement",
+        display: "Kaboom Refinement",
+        meta: {
+          clauses: [
+            {
+              id: "eq",
+              display: "Is Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "dne",
+              display: "Is Not Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "gt",
+              display: "Is Greater Than",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "gte",
+              display: "Is Greater Than Or Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            { id: "lt", display: "Is Less Than", meta: {} },
+            {
+              id: "lte",
+              display: "Is Less Than Or Equal To",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "btwn",
+              display: "Is Between",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "nbtwn",
+              display: "Is Not Between",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "st",
+              display: "Is Set",
+              meta: {},
+              component: "refine-number-input",
+            },
+            {
+              id: "nst",
+              display: "Is Not Set",
+              meta: {},
+              component: "refine-number-input",
+            },
+          ],
+        },
+        refinements: [],
+      },
+    ],
+  },
+];
+
 export default {
   name: "App",
   data() {
@@ -564,13 +702,16 @@ export default {
       conditions,
       groupedBlueprint,
       errors: {
-        0: [{ 
-            id: 23434, 
+        0: [
+          {
+            id: 23434,
             message: "You messed up big time",
-          }, {
+          },
+          {
             id: 454534,
-            message: "Good luck with your life"
-          }]
+            message: "Good luck with your life",
+          },
+        ],
       },
     };
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,12 +30,15 @@
       ],
       "types": [
         "dist/types/index.d.ts"
+      ],
+      "types/internal": [
+        "dist/types/internal/index.d.ts"
       ]
     }
   },
   "packageManager": "yarn@3.1.1",
   "scripts": {
-    "build": "tsup src/index.ts src/fixtures/index.ts src/types/index.ts --format esm,cjs --dts",
+    "build": "tsup src/index.ts src/fixtures/index.ts src/types/index.ts src/types/internal/index.ts --format esm,cjs --dts",
     "dev": "yarn build --watch"
   },
   "devDependencies": {

--- a/packages/core/src/fixtures/conditions.ts
+++ b/packages/core/src/fixtures/conditions.ts
@@ -1,4 +1,4 @@
-import { Condition } from "types";
+import type { Condition } from "types";
 
 export const optionCondition: Condition = {
   id: "option",

--- a/packages/core/src/stores/blueprint.ts
+++ b/packages/core/src/stores/blueprint.ts
@@ -1,9 +1,11 @@
 import type {
   Blueprint,
   Condition,
-  Conjunction,
   Criterion,
   GroupedBlueprint,
+  InternalBlueprint,
+  InternalConjunction,
+  InternalCriterion,
   Refinement,
 } from "types";
 import { isConjunction, isCriterion } from "types";
@@ -60,18 +62,6 @@ const and = function (
     uid: getNextUid(),
   };
 };
-
-type InternalCriterion = Criterion & {
-  id: Criterion["condition_id"];
-  uid: number;
-};
-
-type InternalConjunction = Conjunction & {
-  id: undefined;
-  uid: number;
-};
-
-type InternalBlueprint = Array<InternalCriterion | InternalConjunction>;
 
 export class BlueprintStore {
   private conditions: Condition[];

--- a/packages/core/src/stores/blueprint.ts
+++ b/packages/core/src/stores/blueprint.ts
@@ -3,6 +3,7 @@ import type {
   Condition,
   Conjunction,
   Criterion,
+  GroupedBlueprint,
   Refinement,
 } from "types";
 import { isConjunction, isCriterion } from "types";
@@ -73,8 +74,8 @@ type InternalConjunction = Conjunction & {
 type InternalBlueprint = Array<InternalCriterion | InternalConjunction>;
 
 export class BlueprintStore {
-  public conditions: Condition[];
-  public blueprint: InternalBlueprint;
+  private conditions: Condition[];
+  private blueprint: InternalBlueprint;
 
   public blueprintChanged: () => void;
 
@@ -118,6 +119,10 @@ export class BlueprintStore {
     });
   }
 
+  public getBlueprint(): Blueprint {
+    return this.blueprint.map(({ id, uid, ...item }) => item);
+  }
+
   public updateBlueprint(newBlueprint: Blueprint) {
     uid = 0;
 
@@ -129,7 +134,7 @@ export class BlueprintStore {
       return [];
     }
 
-    const groupedBlueprint = [];
+    const groupedBlueprint: GroupedBlueprint = [];
 
     // start with an empty group
     groupedBlueprint.push([]);
@@ -165,7 +170,7 @@ export class BlueprintStore {
 
   public replaceCriterion(
     previousIndex: number,
-    nextCriterion: InternalCriterion
+    nextCriterion: Pick<InternalCriterion, "id">
   ) {
     const { meta, id, refinements } = this.findCondition(nextCriterion.id);
     const newCriterion = criterion(id, 1, meta, refinements);
@@ -235,7 +240,7 @@ export class BlueprintStore {
     this.blueprintChanged();
   }
 
-  public addCriterion(newCriterion: InternalCriterion) {
+  public addCriterion(newCriterion: Pick<InternalCriterion, "id" | "depth">) {
     const { id, depth } = newCriterion;
     const { blueprint } = this;
     const generatedCriterion = criterion(id, depth);

--- a/packages/core/src/stores/blueprint.ts
+++ b/packages/core/src/stores/blueprint.ts
@@ -1,13 +1,10 @@
-import type {
-  Blueprint,
-  Condition,
-  Criterion,
+import type { Blueprint, Condition, Criterion, Refinement } from "types";
+import {
   GroupedBlueprint,
   InternalBlueprint,
   InternalConjunction,
   InternalCriterion,
-  Refinement,
-} from "types";
+} from "types/internal";
 import { isConjunction, isCriterion } from "types";
 
 let uid = 0;

--- a/packages/core/src/types/blueprint.ts
+++ b/packages/core/src/types/blueprint.ts
@@ -34,30 +34,8 @@ export type BlueprintItem = Criterion | Conjunction;
 
 export type Blueprint = BlueprintItem[];
 
-export type GroupedBlueprint = (Criterion & { position: number })[][];
-
 export const isCriterion = (value: unknown): value is Criterion =>
   (value as any)?.type === "criterion";
 
 export const isConjunction = (value: unknown): value is Conjunction =>
   (value as any)?.type === "conjunction";
-
-/**
- * The `BlueprintStore` modifies the some types as below:
- */
-
-export type InternalCriterion = Criterion & {
-  id: Criterion["condition_id"];
-  uid: number;
-};
-
-export type InternalCriterionWithPosition = InternalCriterion & {
-  position: number;
-};
-
-export type InternalConjunction = Conjunction & {
-  id: undefined;
-  uid: number;
-};
-
-export type InternalBlueprint = Array<InternalCriterion | InternalConjunction>;

--- a/packages/core/src/types/blueprint.ts
+++ b/packages/core/src/types/blueprint.ts
@@ -34,7 +34,7 @@ export type BlueprintItem = Criterion | Conjunction;
 
 export type Blueprint = BlueprintItem[];
 
-export type GroupedBlueprint = Criterion[][];
+export type GroupedBlueprint = (Criterion & { position: number })[][];
 
 export const isCriterion = (value: unknown): value is Criterion =>
   (value as any)?.type === "criterion";

--- a/packages/core/src/types/blueprint.ts
+++ b/packages/core/src/types/blueprint.ts
@@ -41,3 +41,23 @@ export const isCriterion = (value: unknown): value is Criterion =>
 
 export const isConjunction = (value: unknown): value is Conjunction =>
   (value as any)?.type === "conjunction";
+
+/**
+ * The `BlueprintStore` modifies the some types as below:
+ */
+
+export type InternalCriterion = Criterion & {
+  id: Criterion["condition_id"];
+  uid: number;
+};
+
+export type InternalCriterionWithPosition = InternalCriterion & {
+  position: number;
+};
+
+export type InternalConjunction = Conjunction & {
+  id: undefined;
+  uid: number;
+};
+
+export type InternalBlueprint = Array<InternalCriterion | InternalConjunction>;

--- a/packages/core/src/types/internal/index.ts
+++ b/packages/core/src/types/internal/index.ts
@@ -1,0 +1,1 @@
+export * from "./internal";

--- a/packages/core/src/types/internal/internal.ts
+++ b/packages/core/src/types/internal/internal.ts
@@ -1,0 +1,23 @@
+/**
+ * The `BlueprintStore` modifies the some types as below:
+ */
+
+import { Conjunction, Criterion } from "../blueprint";
+
+export type InternalCriterion = Criterion & {
+  id: Criterion["condition_id"];
+  uid: number;
+};
+
+export type InternalCriterionWithPosition = InternalCriterion & {
+  position: number;
+};
+
+export type InternalConjunction = Conjunction & {
+  id: undefined;
+  uid: number;
+};
+
+export type InternalBlueprint = Array<InternalCriterion | InternalConjunction>;
+
+export type GroupedBlueprint = InternalCriterionWithPosition[][];

--- a/packages/refine-react/src/index.ts
+++ b/packages/refine-react/src/index.ts
@@ -1,1 +1,2 @@
+export * from "refine-core/types";
 export * from "./tailwind";

--- a/packages/refine-react/src/tailwind/components/conditions/condition.tsx
+++ b/packages/refine-react/src/tailwind/components/conditions/condition.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo } from "react";
-import type { Condition as ConditionType, Criterion } from "refine-core/types";
+import { useMemo } from "react";
+import type { Condition as ConditionType } from "refine-core/types";
 import { useCriterion } from "../criterion";
 import inputComponents from "../inputs";
-import { InputProvider, valueToArray } from "../inputs/use-input";
+import { InputProvider } from "../inputs/use-input";
 import { useQueryBuilder } from "../query-builder/use-query-builder";
 import { useSelectedClause } from "./use-selected-clause";
 
@@ -11,7 +11,7 @@ export type ConditionProps = {
 };
 
 export const Condition = ({ condition }: ConditionProps) => {
-  const { conditions } = useQueryBuilder();
+  const { blueprint, conditions } = useQueryBuilder();
   const criterion = useCriterion();
   const selectedClause = useSelectedClause(condition, criterion.input.clause);
 
@@ -28,76 +28,16 @@ export const Condition = ({ condition }: ConditionProps) => {
     return null;
   }, [selectedClause?.component]);
 
-  /**
-   * When changing to a clause which doesn't have an input value,
-   * remove the input value.
-   */
-  useEffect(() => {
-    if (!hasInput && criterion.input.value != null) {
-      criterion.update((criterion) => {
-        const { value, ...input } = criterion.input;
-
-        return {
-          ...criterion,
-          input,
-        };
-      });
-    }
-  }, [selectedClause]);
-
-  /**
-   * When changing from a single option to a multiple option, convert
-   * to/from array as needed.
-   */
-  useEffect(() => {
-    if (selectedClause.meta.multiple && !Array.isArray(criterion.input.value)) {
-      return criterion.update((criterion) => ({
-        ...criterion,
-        input: {
-          ...criterion.input,
-          value: valueToArray(criterion.input.value),
-        },
-      }));
-    }
-
-    if (!selectedClause.meta.multiple && Array.isArray(criterion.input.value)) {
-      return criterion.update((criterion) => ({
-        ...criterion,
-        input: {
-          ...criterion.input,
-          value: criterion.input.value ?? "",
-        },
-      }));
-    }
-  }, [selectedClause.meta.multiple]);
-
-  const updateCondition = (conditionId: ConditionType["id"]) => {
-    const targetCondition = conditions.find(
-      (condition) => condition.id === conditionId
-    );
-
-    if (!targetCondition) return;
-
-    criterion.update((criterion) => {
-      const selectedClauseIsValidForTargetCondition =
-        !!targetCondition.meta.clauses.find(
-          (clause) => clause.id === criterion.input.clause
-        );
-
-      const input: Criterion["input"] = selectedClauseIsValidForTargetCondition
-        ? criterion.input
-        : { clause: targetCondition.meta.clauses[0].id };
-
-      return { ...criterion, condition_id: targetCondition.id, input };
-    });
-  };
-
   return (
     <div data-testid="refine-condition" className="flex space-x-2">
       <div>
         <select
           value={condition.id}
-          onChange={(event) => updateCondition(event.target.value)}
+          onChange={(event) => {
+            blueprint.replaceCriterion(criterion.position, {
+              id: event.target.value,
+            });
+          }}
           className="bg-white relative w-full border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
         >
           {conditions.map((condition) => (
@@ -110,12 +50,11 @@ export const Condition = ({ condition }: ConditionProps) => {
       <div>
         <select
           value={selectedClause.id}
-          onChange={(event) =>
-            criterion.update((criterion) => ({
-              ...criterion,
-              input: { ...criterion.input, clause: event.target.value },
-            }))
-          }
+          onChange={(event) => {
+            blueprint.updateInput(criterion, {
+              clause: event.target.value,
+            });
+          }}
           className="bg-white relative w-full border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
         >
           {condition.meta.clauses.map((clause) => (
@@ -131,11 +70,11 @@ export const Condition = ({ condition }: ConditionProps) => {
             display: selectedClause.display,
             options: condition.meta.options,
             value: criterion.input.value ?? "",
-            onChange: (value) =>
-              criterion.update((criterion) => ({
-                ...criterion,
-                input: { ...criterion.input, value },
-              })),
+            onChange: (value) => {
+              blueprint.updateInput(criterion, {
+                value,
+              });
+            },
             multiple: selectedClause.meta.multiple ?? false,
           }}
         >

--- a/packages/refine-react/src/tailwind/components/conditions/condition.tsx
+++ b/packages/refine-react/src/tailwind/components/conditions/condition.tsx
@@ -11,7 +11,7 @@ export type ConditionProps = {
 };
 
 export const Condition = ({ condition }: ConditionProps) => {
-  const { blueprint, conditions } = useQueryBuilder();
+  const { conditions } = useQueryBuilder();
   const criterion = useCriterion();
   const selectedClause = useSelectedClause(condition, criterion.input.clause);
 
@@ -22,6 +22,7 @@ export const Condition = ({ condition }: ConditionProps) => {
       selectedClause.component &&
       selectedClause.component in inputComponents
     ) {
+      // @ts-expect-error
       return inputComponents[selectedClause.component];
     }
 
@@ -33,11 +34,7 @@ export const Condition = ({ condition }: ConditionProps) => {
       <div>
         <select
           value={condition.id}
-          onChange={(event) => {
-            blueprint.replaceCriterion(criterion.position, {
-              id: event.target.value,
-            });
-          }}
+          onChange={(event) => criterion.updateCondition(event.target.value)}
           className="bg-white relative w-full border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
         >
           {conditions.map((condition) => (
@@ -50,11 +47,11 @@ export const Condition = ({ condition }: ConditionProps) => {
       <div>
         <select
           value={selectedClause.id}
-          onChange={(event) => {
-            blueprint.updateInput(criterion, {
+          onChange={(event) =>
+            criterion.updateInput({
               clause: event.target.value,
-            });
-          }}
+            })
+          }
           className="bg-white relative w-full border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
         >
           {condition.meta.clauses.map((clause) => (
@@ -70,11 +67,7 @@ export const Condition = ({ condition }: ConditionProps) => {
             display: selectedClause.display,
             options: condition.meta.options,
             value: criterion.input.value ?? "",
-            onChange: (value) => {
-              blueprint.updateInput(criterion, {
-                value,
-              });
-            },
+            onChange: (value) => criterion.updateInput({ value }),
             multiple: selectedClause.meta.multiple ?? false,
           }}
         >

--- a/packages/refine-react/src/tailwind/components/conditions/text-condition.tsx
+++ b/packages/refine-react/src/tailwind/components/conditions/text-condition.tsx
@@ -3,14 +3,8 @@ import { useSelectedClause } from "./use-selected-clause";
 
 export interface TextConditionProps extends BaseConditionProps {}
 
-export const TextCondition = ({
-  condition,
-  blueprintItem,
-}: TextConditionProps) => {
-  const selectedClause = useSelectedClause(
-    condition,
-    blueprintItem.input.clause
-  );
+export const TextCondition = ({ condition, criterion }: TextConditionProps) => {
+  const selectedClause = useSelectedClause(condition, criterion.input.clause);
 
   const showThirdColumn = !!selectedClause?.component;
 

--- a/packages/refine-react/src/tailwind/components/conditions/use-condition.ts
+++ b/packages/refine-react/src/tailwind/components/conditions/use-condition.ts
@@ -1,4 +1,4 @@
-import { Condition } from "refine-core/types";
+import type { Condition } from "refine-core/types";
 import { useQueryBuilder } from "../query-builder/use-query-builder";
 
 export const useCondition = (id: Condition["id"]) => {

--- a/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
+++ b/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
@@ -1,80 +1,25 @@
-import { Criterion as CriterionType } from "refine-core/types";
+import { GroupedBlueprint } from "refine-core/types";
 import { Criterion } from "../criterion";
 import { useQueryBuilder } from "../query-builder/use-query-builder";
-import {
-  CriterionGroupContext,
-  CriterionGroupProvider,
-} from "./use-criterion-group";
+import { CriterionGroupProvider } from "./use-criterion-group";
 
-type CriterionGroupProps = {
+export type CriterionGroupProps = {
   index: number;
-  criteria: CriterionType[];
+  criteria: GroupedBlueprint[number];
 };
 
 export const CriterionGroup = ({ index, criteria }: CriterionGroupProps) => {
-  const { blueprint, groupedBlueprint, updateGroupedBlueprint } =
-    useQueryBuilder();
+  const { blueprint, groupedBlueprint } = useQueryBuilder();
   const group = groupedBlueprint[index];
 
-  const modify: CriterionGroupContext["modify"] = (payloadOrUpdateFn) => {
-    updateGroupedBlueprint((groupedBlueprint) =>
-      groupedBlueprint
-        .map((criteria, groupIndex) => {
-          if (groupIndex === index) {
-            return typeof payloadOrUpdateFn === "function"
-              ? payloadOrUpdateFn(criteria)
-              : payloadOrUpdateFn;
-          }
-
-          return criteria;
-        })
-        .filter((value): value is CriterionType[] => value !== null)
-    );
-  };
-
-  const addCriterion: CriterionGroupContext["addCriterion"] = (payload) =>
-    modify((criteria) => [...criteria, payload]);
-
-  const updateCriterion: CriterionGroupContext["updateCriterion"] = (
-    targetCriterionIndex,
-    payload
-  ) =>
-    modify((criteria) =>
-      criteria.map((criterion, criterionIndex) => {
-        if (criterionIndex === targetCriterionIndex) {
-          return typeof payload === "function" ? payload(criterion) : payload;
-        }
-        return criterion;
-      })
-    );
-
-  const removeCriterion: CriterionGroupContext["removeCriterion"] = (
-    targetCriterionIndex
-  ) =>
-    modify((criteria) => {
-      const updatedCriteria = criteria.filter(
-        (criterion, criterionIndex) => criterionIndex !== targetCriterionIndex
-      );
-
-      /**
-       * If removing the last criteria from a group, remove the group.
-       */
-      if (updatedCriteria.length === 0) {
-        return null;
-      }
-
-      return updatedCriteria;
-    });
+  const addCriterion = () =>
+    blueprint.insertCriterion(group[group.length - 1].position);
 
   return (
     <CriterionGroupProvider
       value={{
         index,
         criteria,
-        modify,
-        addCriterion,
-        updateCriterion,
-        removeCriterion,
       }}
     >
       <div
@@ -87,10 +32,7 @@ export const CriterionGroup = ({ index, criteria }: CriterionGroupProps) => {
         <button
           data-testid="refine-add-criterion"
           type="button"
-          onClick={() => {
-            console.log("add criterion");
-            blueprint.insertCriterion(group[group.length - 1].position);
-          }}
+          onClick={() => addCriterion()}
           className="background-transparent text-blue-600 text-xs flex items-center py-1 px-3 mt-3"
         >
           <svg

--- a/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
+++ b/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
@@ -1,4 +1,4 @@
-import { InternalCriterionWithPosition } from "refine-core/types";
+import type { InternalCriterionWithPosition } from "refine-core/types/internal";
 import { Criterion } from "../criterion";
 import { useQueryBuilder } from "../query-builder/use-query-builder";
 import { CriterionGroupProvider } from "./use-criterion-group";

--- a/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
+++ b/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
@@ -1,5 +1,4 @@
-import { Criterion } from "refine-core/types";
-import { getDefaultCriterion } from "..";
+import { Criterion as CriterionType } from "refine-core/types";
 import { Criterion } from "../criterion";
 import { useQueryBuilder } from "../query-builder/use-query-builder";
 import {
@@ -9,11 +8,13 @@ import {
 
 type CriterionGroupProps = {
   index: number;
-  criteria: Criterion[];
+  criteria: CriterionType[];
 };
 
 export const CriterionGroup = ({ index, criteria }: CriterionGroupProps) => {
-  const { conditions, updateGroupedBlueprint } = useQueryBuilder();
+  const { blueprint, groupedBlueprint, updateGroupedBlueprint } =
+    useQueryBuilder();
+  const group = groupedBlueprint[index];
 
   const modify: CriterionGroupContext["modify"] = (payloadOrUpdateFn) => {
     updateGroupedBlueprint((groupedBlueprint) =>
@@ -27,7 +28,7 @@ export const CriterionGroup = ({ index, criteria }: CriterionGroupProps) => {
 
           return criteria;
         })
-        .filter((value): value is Criterion[] => value !== null)
+        .filter((value): value is CriterionType[] => value !== null)
     );
   };
 
@@ -65,10 +66,6 @@ export const CriterionGroup = ({ index, criteria }: CriterionGroupProps) => {
       return updatedCriteria;
     });
 
-  const addDefaultCriterion = () => {
-    addCriterion(getDefaultCriterion(conditions));
-  };
-
   return (
     <CriterionGroupProvider
       value={{
@@ -90,7 +87,10 @@ export const CriterionGroup = ({ index, criteria }: CriterionGroupProps) => {
         <button
           data-testid="refine-add-criterion"
           type="button"
-          onClick={() => addDefaultCriterion()}
+          onClick={() => {
+            console.log("add criterion");
+            blueprint.insertCriterion(group[group.length - 1].position);
+          }}
           className="background-transparent text-blue-600 text-xs flex items-center py-1 px-3 mt-3"
         >
           <svg

--- a/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
+++ b/packages/refine-react/src/tailwind/components/criterion-group/criterion-group.tsx
@@ -1,11 +1,11 @@
-import { GroupedBlueprint } from "refine-core/types";
+import { InternalCriterionWithPosition } from "refine-core/types";
 import { Criterion } from "../criterion";
 import { useQueryBuilder } from "../query-builder/use-query-builder";
 import { CriterionGroupProvider } from "./use-criterion-group";
 
 export type CriterionGroupProps = {
   index: number;
-  criteria: GroupedBlueprint[number];
+  criteria: InternalCriterionWithPosition[];
 };
 
 export const CriterionGroup = ({ index, criteria }: CriterionGroupProps) => {

--- a/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
+++ b/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
@@ -1,9 +1,9 @@
 import { createContext, useContext } from "react";
-import { Criterion } from "refine-core/types";
+import { Criterion, GroupedBlueprint } from "refine-core/types";
 
 export type CriterionGroupContext = {
   index: number;
-  criteria: Criterion[];
+  criteria: GroupedBlueprint[number];
   modify: {
     (payload: Criterion[] | null): void;
     (updateFn: (criteria: Criterion[]) => Criterion[] | null): void;

--- a/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
+++ b/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
@@ -1,19 +1,9 @@
 import { createContext, useContext } from "react";
-import { Criterion, GroupedBlueprint } from "refine-core/types";
+import { GroupedBlueprint } from "refine-core/types";
 
 export type CriterionGroupContext = {
   index: number;
   criteria: GroupedBlueprint[number];
-  modify: {
-    (payload: Criterion[] | null): void;
-    (updateFn: (criteria: Criterion[]) => Criterion[] | null): void;
-  };
-  addCriterion: (payload: Criterion) => void;
-  updateCriterion: {
-    (index: number, payload: Criterion): void;
-    (index: number, updateFn: (criterion: Criterion) => Criterion): void;
-  };
-  removeCriterion: (index: number) => void;
 };
 
 export const CriterionGroupContext =

--- a/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
+++ b/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import { InternalCriterionWithPosition } from "refine-core/types";
+import type { InternalCriterionWithPosition } from "refine-core/types/internal";
 
 export type CriterionGroupContext = {
   index: number;

--- a/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
+++ b/packages/refine-react/src/tailwind/components/criterion-group/use-criterion-group.ts
@@ -1,9 +1,9 @@
 import { createContext, useContext } from "react";
-import { GroupedBlueprint } from "refine-core/types";
+import { InternalCriterionWithPosition } from "refine-core/types";
 
 export type CriterionGroupContext = {
   index: number;
-  criteria: GroupedBlueprint[number];
+  criteria: InternalCriterionWithPosition[];
 };
 
 export const CriterionGroupContext =

--- a/packages/refine-react/src/tailwind/components/criterion/criterion.tsx
+++ b/packages/refine-react/src/tailwind/components/criterion/criterion.tsx
@@ -1,4 +1,3 @@
-import { CriterionContext } from ".";
 import { Condition } from "../conditions/condition";
 import { useCondition } from "../conditions/use-condition";
 import { useCriterionGroup } from "../criterion-group/use-criterion-group";
@@ -22,12 +21,17 @@ export const Criterion = ({ index }: CriterionProps) => {
 
   const condition = useCondition(criterion.condition_id);
 
-  const update: CriterionContext["update"] = (payloadOrUpdateFn) =>
-    group.updateCriterion(index, payloadOrUpdateFn);
-  const remove: CriterionContext["remove"] = () => group.removeCriterion(index);
-
   return (
-    <CriterionProvider value={{ update, remove, ...criterion }}>
+    <CriterionProvider
+      value={{
+        updateCondition: (conditionId) =>
+          blueprint.replaceCriterion(criterion.position, {
+            id: conditionId,
+          }),
+        updateInput: (input) => blueprint.updateInput(criterion, input),
+        ...criterion,
+      }}
+    >
       <div
         data-testid="refine-criterion"
         className="flex items-center space-x-3"

--- a/packages/refine-react/src/tailwind/components/criterion/criterion.tsx
+++ b/packages/refine-react/src/tailwind/components/criterion/criterion.tsx
@@ -2,6 +2,7 @@ import { CriterionContext } from ".";
 import { Condition } from "../conditions/condition";
 import { useCondition } from "../conditions/use-condition";
 import { useCriterionGroup } from "../criterion-group/use-criterion-group";
+import { useQueryBuilder } from "../query-builder/use-query-builder";
 import { CriterionProvider } from "./use-criterion";
 
 export type CriterionProps = {
@@ -9,6 +10,7 @@ export type CriterionProps = {
 };
 
 export const Criterion = ({ index }: CriterionProps) => {
+  const { blueprint } = useQueryBuilder();
   const { criteria, ...group } = useCriterionGroup();
   const criterion = criteria[index];
 
@@ -33,7 +35,7 @@ export const Criterion = ({ index }: CriterionProps) => {
         <button
           data-testid="refine-remove-criterion"
           className="inline-flex items-center justify-center py-1 px-3 text-gray-500"
-          onClick={() => remove()}
+          onClick={() => blueprint.removeCriterion(criterion.position)}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
+++ b/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
-import { Criterion } from "refine-core/types";
+import { Criterion, GroupedBlueprint } from "refine-core/types";
 
-export type CriterionContext = Criterion & {
+export type CriterionContext = GroupedBlueprint[number][number] & {
   update: (
     payloadOrUpdateFn: Criterion | ((payload: Criterion) => Criterion)
   ) => void;

--- a/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
+++ b/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
-import { Criterion, GroupedBlueprint } from "refine-core/types";
+import { Criterion, InternalCriterionWithPosition } from "refine-core/types";
 
-export type CriterionContext = GroupedBlueprint[number][number] & {
+export type CriterionContext = InternalCriterionWithPosition & {
   updateCondition: (conditionId: Criterion["condition_id"]) => void;
   updateInput: (input: Partial<Criterion["input"]>) => void;
 };

--- a/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
+++ b/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
@@ -2,10 +2,8 @@ import { createContext, useContext } from "react";
 import { Criterion, GroupedBlueprint } from "refine-core/types";
 
 export type CriterionContext = GroupedBlueprint[number][number] & {
-  update: (
-    payloadOrUpdateFn: Criterion | ((payload: Criterion) => Criterion)
-  ) => void;
-  remove: () => void;
+  updateCondition: (conditionId: Criterion["condition_id"]) => void;
+  updateInput: (input: Partial<Criterion["input"]>) => void;
 };
 
 export const CriterionContext = createContext<CriterionContext | null>(null);

--- a/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
+++ b/packages/refine-react/src/tailwind/components/criterion/use-criterion.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from "react";
-import { Criterion, InternalCriterionWithPosition } from "refine-core/types";
+import type { Criterion } from "refine-core/types";
+import type { InternalCriterionWithPosition } from "refine-core/types/internal";
 
 export type CriterionContext = InternalCriterionWithPosition & {
   updateCondition: (conditionId: Criterion["condition_id"]) => void;

--- a/packages/refine-react/src/tailwind/components/inputs/use-input.ts
+++ b/packages/refine-react/src/tailwind/components/inputs/use-input.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import { Option } from "refine-core/types";
+import type { Option } from "refine-core/types";
 
 export type InputContext<Value = any> = {
   display: string;

--- a/packages/refine-react/src/tailwind/components/query-builder/query-builder.tsx
+++ b/packages/refine-react/src/tailwind/components/query-builder/query-builder.tsx
@@ -1,10 +1,5 @@
-import React, { useEffect, useReducer, useState } from "react";
-import {
-  Blueprint,
-  Condition,
-  Criterion,
-  GroupedBlueprint,
-} from "refine-core/types";
+import React, { useReducer, useState } from "react";
+import { Blueprint, Condition } from "refine-core/types";
 import { BlueprintStore } from "refine-core";
 import { CriterionGroup } from "../criterion-group";
 import { QueryBuilderProvider } from "./use-query-builder";
@@ -40,7 +35,6 @@ export const QueryBuilder = ({
       value={{
         blueprint: blueprint,
         groupedBlueprint: blueprint.groupedBlueprint(),
-        updateGroupedBlueprint: () => {},
         conditions,
       }}
     >

--- a/packages/refine-react/src/tailwind/components/query-builder/query-builder.tsx
+++ b/packages/refine-react/src/tailwind/components/query-builder/query-builder.tsx
@@ -1,89 +1,57 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useReducer, useState } from "react";
 import {
   Blueprint,
   Condition,
   Criterion,
   GroupedBlueprint,
 } from "refine-core/types";
+import { BlueprintStore } from "refine-core";
 import { CriterionGroup } from "../criterion-group";
 import { QueryBuilderProvider } from "./use-query-builder";
 
 export type QueryBuilderProps = {
   blueprint: Blueprint;
   conditions: Condition[];
-  onChange?: (blueprint: GroupedBlueprint) => void;
+  onChange?: (blueprint: Blueprint) => void;
 };
 
-export const groupBlueprintItems = (blueprint: Blueprint): GroupedBlueprint => {
-  const groupedBlueprint: GroupedBlueprint = [];
-  let currentGroupIndex = 0;
+const useRerender = () => {
+  const [, rerender] = useReducer(() => null, null);
 
-  for (const item of blueprint) {
-    if (item.type === "conjunction") {
-      if (item.word === "or") {
-        currentGroupIndex++;
-      }
-    }
-
-    if (item.type === "criterion") {
-      if (!Array.isArray(groupedBlueprint[currentGroupIndex])) {
-        groupedBlueprint.push([]);
-      }
-
-      groupedBlueprint[currentGroupIndex].push(item);
-    }
-  }
-
-  return groupedBlueprint;
+  return rerender;
 };
-
-export const getDefaultCriterion = (conditions: Condition[]): Criterion => ({
-  type: "criterion",
-  depth: 1,
-  condition_id: conditions[0].id,
-  input: { clause: conditions[0].meta.clauses[0].id },
-});
 
 export const QueryBuilder = ({
   blueprint: initialBlueprint,
   conditions,
   onChange,
 }: QueryBuilderProps) => {
-  const [groupedBlueprint, setGroupedBlueprint] = useState(() =>
-    groupBlueprintItems(initialBlueprint)
+  const rerender = useRerender();
+  const [blueprint] = useState(
+    () =>
+      new BlueprintStore(initialBlueprint, conditions, (blueprint) => {
+        onChange?.(blueprint);
+        rerender();
+      })
   );
-
-  useEffect(() => {
-    if (onChange) {
-      onChange(groupedBlueprint);
-    }
-  }, [groupedBlueprint]);
-
-  const addGroup = () => {
-    const newCriterionGroup: Criterion[] = [getDefaultCriterion(conditions)];
-
-    return setGroupedBlueprint((groupedBlueprint) => [
-      ...groupedBlueprint,
-      newCriterionGroup,
-    ]);
-  };
 
   return (
     <QueryBuilderProvider
       value={{
-        groupedBlueprint,
-        updateGroupedBlueprint: setGroupedBlueprint,
+        blueprint: blueprint,
+        groupedBlueprint: blueprint.groupedBlueprint(),
+        updateGroupedBlueprint: () => {},
         conditions,
       }}
     >
       <div data-testid="refine-query-builder">
-        {groupedBlueprint.map((criteria, index) => (
+        {blueprint.groupedBlueprint().map((criteria, index) => (
           <CriterionGroup key={index} criteria={criteria} index={index} />
         ))}
         <button
           data-testid="refine-add-criterion-group"
           type="button"
-          onClick={addGroup}
+          onClick={() => blueprint.addGroup()}
           className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
         >
           Add an 'Or'

--- a/packages/refine-react/src/tailwind/components/query-builder/query-builder.tsx
+++ b/packages/refine-react/src/tailwind/components/query-builder/query-builder.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer, useState } from "react";
-import { Blueprint, Condition } from "refine-core/types";
+import type { Blueprint, Condition } from "refine-core/types";
 import { BlueprintStore } from "refine-core";
 import { CriterionGroup } from "../criterion-group";
 import { QueryBuilderProvider } from "./use-query-builder";

--- a/packages/refine-react/src/tailwind/components/query-builder/use-query-builder.tsx
+++ b/packages/refine-react/src/tailwind/components/query-builder/use-query-builder.tsx
@@ -1,7 +1,9 @@
 import { createContext, useContext } from "react";
+import { BlueprintStore } from "refine-core";
 import { Condition, GroupedBlueprint } from "refine-core/types";
 
 export type QueryBuilderContext = {
+  blueprint: BlueprintStore;
   groupedBlueprint: GroupedBlueprint;
   updateGroupedBlueprint: {
     (payload: GroupedBlueprint): void;

--- a/packages/refine-react/src/tailwind/components/query-builder/use-query-builder.tsx
+++ b/packages/refine-react/src/tailwind/components/query-builder/use-query-builder.tsx
@@ -5,10 +5,6 @@ import { Condition, GroupedBlueprint } from "refine-core/types";
 export type QueryBuilderContext = {
   blueprint: BlueprintStore;
   groupedBlueprint: GroupedBlueprint;
-  updateGroupedBlueprint: {
-    (payload: GroupedBlueprint): void;
-    (updateFn: (criterion: GroupedBlueprint) => GroupedBlueprint): void;
-  };
   conditions: Condition[];
 };
 

--- a/packages/refine-react/src/tailwind/components/query-builder/use-query-builder.tsx
+++ b/packages/refine-react/src/tailwind/components/query-builder/use-query-builder.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react";
 import { BlueprintStore } from "refine-core";
-import { Condition, GroupedBlueprint } from "refine-core/types";
+import type { Condition } from "refine-core/types";
+import type { GroupedBlueprint } from "refine-core/types/internal";
 
 export type QueryBuilderContext = {
   blueprint: BlueprintStore;


### PR DESCRIPTION
This PR:
- Refactors the React implementation to use the `BlueprintStore` from `refine-core`
- Tidies up types

Internally we can use `refine-core/types` and `refine-core/types/internal`. Internal types include things like the `GroupedBlueprint` and things like the modified `Criterion` type with a `uid` and `position`.

Everything from `refine-core/types` is re-exported from `@hammerstone/refine-react` so end users can import the types for blueprints, conditions, etc.

We can also add these types to the Vue import if we create a type definition file for it (we can do that without rewriting the whole library to TypeScript.

